### PR TITLE
Ligature Support

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -31,7 +31,7 @@
   "globalstrict"  : true,   // Allow global "use strict" (also enables 'strict').
   "iterator"      : false,  // Allow usage of __iterator__ property.
   "lastsemic"     : false,  // Tolerate semicolon omited for the last statement.
-  "laxbreak"      : false,  // Tolerate unsafe line breaks e.g. `return [\n] x` without semicolons.
+  "laxbreak"      : true,  // Tolerate unsafe line breaks e.g. `return [\n] x` without semicolons.
   "laxcomma"      : true,   // This option suppresses warnings about comma-first coding style
   "loopfunc"      : false,  // Allow functions to be defined within loops.
   "multistr"      : false,  // Tolerate multi-line strings.

--- a/lib/byte_buffer.js
+++ b/lib/byte_buffer.js
@@ -130,11 +130,6 @@ ByteBuffer.prototype.fill = function (value) {
   }
 };
 
-ByteBuffer.prototype.create = function (size) {
-  var buf = Uint8Array ? new Uint8Array(size) : new Array(size);
-  return new ByteBuffer(buf);
-};
-
 ByteBuffer.prototype.writeUint64 = function (value) {
   // we canot use bitwise operations for 64bit values because of JavaScript limitations,
   // instead we should divide it to 2 Int32 numbers
@@ -183,6 +178,9 @@ ByteBuffer.prototype.toArray = function () {
   }
 };
 
-
+ByteBuffer.create = function (size) {
+  var buf = Uint8Array ? new Uint8Array(size) : new Array(size);
+  return new ByteBuffer(buf);
+};
 
 module.exports = ByteBuffer;

--- a/lib/sfnt.js
+++ b/lib/sfnt.js
@@ -7,6 +7,10 @@ var Font = function () {
   this.copyright = '';
   this.createdDate = new Date();
   this.glyphs = [];
+  this.ligatures = [];
+  // Maping of code points to glyphs.
+  // Keys are actually numeric, thus should be `parseInt`ed.
+  this.codePoints = {};
   this.isFixedPitch = 0;
   this.italicAngle = 0;
   this.familyClass = 0; // No Classification
@@ -242,7 +246,6 @@ var Glyph = function () {
   this.lsb = 0;
   this.name = '';
   this.size = 0;
-  this.unicode = 0;
   this.width = 0;
 };
 

--- a/lib/svg.js
+++ b/lib/svg.js
@@ -3,29 +3,25 @@
 var _ = require('lodash');
 var DOMParser = require('xmldom').DOMParser;
 var math  = require('./math');
-
-// supports multibyte characters
-function getUnicode(character) {
-  if (character.length === 1) {
-    // 2 bytes
-    return character.charCodeAt(0);
-  } else if (character.length === 2) {
-    // 4 bytes
-    var surrogate1 = character.charCodeAt(0);
-    var surrogate2 = character.charCodeAt(1);
-    /*jshint bitwise: false*/
-    return ((surrogate1 & 0x3FF) << 10) + (surrogate2 & 0x3FF) + 0x10000;
-  }
-}
+var ucs2 = require('./ucs2');
 
 function getGlyph(glyphElem) {
   var glyph = {};
 
-  glyph.d = glyphElem.getAttribute('d');
+  glyph.d = glyphElem.getAttribute('d').trim();
+  glyph.unicode = [];
 
   if (glyphElem.getAttribute('unicode')) {
     glyph.character = glyphElem.getAttribute('unicode');
-    glyph.unicode = getUnicode(glyph.character);
+    var unicode = ucs2.decode(glyph.character);
+
+    // If more than one code point is involved, the glyph is a ligature glyph
+    if(unicode.length > 1) {
+      glyph.ligature = glyph.character;
+      glyph.ligatureCodes = unicode;
+    } else {
+      glyph.unicode.push(unicode[0]);
+    }
   }
 
   glyph.name = glyphElem.getAttribute('glyph-name');
@@ -37,10 +33,37 @@ function getGlyph(glyphElem) {
   return glyph;
 }
 
+function deduplicateGlyps(glyphs, ligatures) {
+  // Result (the list of unique glyphs)
+  var result = [];
+
+  _.forEach(glyphs, function(glyph) {
+    // Search for glyphs with the same properties (width and d)
+    var canonical = _.find(result, {width: glyph.width, d: glyph.d});
+    if(canonical) {
+      // Add the code points to the unicode array.
+      // The fields “name” and “character” are not that important so we leave them how we first enounter them and throw the rest away
+      canonical.unicode = canonical.unicode.concat(glyph.unicode);
+      glyph.canonical = canonical;
+    } else {
+      result.push(glyph);
+    }
+  });
+
+  // Update ligatures to point to the canonical version
+  _.forEach(ligatures, function(ligature) {
+    while(_.has(ligature.glyph, 'canonical')) {
+      ligature.glyph = ligature.glyph.canonical;
+    }
+  });
+
+  return result;
+}
+
 function load(str) {
   var attrs;
 
-  var doc = (new DOMParser()).parseFromString(str, "application/xml");
+  var doc = (new DOMParser()).parseFromString(str, 'application/xml');
 
   var metadata = doc.getElementsByTagName('metadata')[0];
   var fontElem = doc.getElementsByTagName('font')[0];
@@ -49,7 +72,6 @@ function load(str) {
   var font = {
     id: fontElem.getAttribute('id') || 'fontello',
     familyName: fontFaceElem.getAttribute('font-family') || 'fontello',
-    glyphs: [],
     stretch: fontFaceElem.getAttribute('font-stretch') || 'normal'
   };
 
@@ -96,9 +118,27 @@ function load(str) {
     }
   }
 
+  var glyphs = [];
+  var ligatures = [];
+
   _.forEach(fontElem.getElementsByTagName('glyph'), function (glyphElem) {
-    font.glyphs.push(getGlyph(glyphElem));
+    var glyph = getGlyph(glyphElem);
+
+    if(_.has(glyph, 'ligature')) {
+      ligatures.push({
+        ligature: glyph.ligature,
+        unicode: glyph.ligatureCodes,
+        glyph: glyph
+      });
+    }
+
+    glyphs.push(glyph);
   });
+
+  glyphs = deduplicateGlyps(glyphs, ligatures);
+
+  font.glyphs = glyphs;
+  font.ligatures = ligatures;
 
   return font;
 }

--- a/lib/ttf.js
+++ b/lib/ttf.js
@@ -3,6 +3,7 @@
 var _ = require('lodash');
 var ByteBuffer = require('./byte_buffer.js');
 
+var createGSUBTable    = require('./ttf/tables/gsub');
 var createOS2Table    = require('./ttf/tables/os2');
 var createCMapTable   = require('./ttf/tables/cmap');
 var createGlyfTable   = require('./ttf/tables/glyf');
@@ -18,16 +19,17 @@ var utils = require('./ttf/utils');
 
 // Tables
 var TABLES = [
-  { innerName: 0x4f532f32, create: createOS2Table, order: 4 }, //OS/2
-  { innerName: 0x636d6170, create: createCMapTable, order: 6 }, // cmap
-  { innerName: 0x676c7966, create: createGlyfTable, order: 8 }, // glyf
-  { innerName: 0x68656164, create: createHeadTable, order: 2 }, // head
-  { innerName: 0x68686561, create: createHHeadTable, order: 1 }, // hhea
-  { innerName: 0x686d7478, create: createHtmxTable, order: 5 }, // hmtx
-  { innerName: 0x6c6f6361, create: createLocaTable, order: 7 }, // loca
-  { innerName: 0x6d617870, create: createMaxpTable, order: 3 }, // maxp
-  { innerName: 0x6e616d65, create: createNameTable, order: 9 }, // name
-  { innerName: 0x706f7374, create: createPostTable, order: 10 } // post
+  { innerName: 'GSUB', order: 4,  create: createGSUBTable  }, // GSUB
+  { innerName: 'OS/2', order: 4,  create: createOS2Table   }, // OS/2
+  { innerName: 'cmap', order: 6,  create: createCMapTable  }, // cmap
+  { innerName: 'glyf', order: 8,  create: createGlyfTable  }, // glyf
+  { innerName: 'head', order: 2,  create: createHeadTable  }, // head
+  { innerName: 'hhea', order: 1,  create: createHHeadTable }, // hhea
+  { innerName: 'hmtx', order: 5,  create: createHtmxTable  }, // hmtx
+  { innerName: 'loca', order: 7,  create: createLocaTable  }, // loca
+  { innerName: 'maxp', order: 3,  create: createMaxpTable  }, // maxp
+  { innerName: 'name', order: 9,  create: createNameTable  }, // name
+  { innerName: 'post', order: 10, create: createPostTable  }  // post
 ];
 
 // Various constants
@@ -112,7 +114,7 @@ function generateTTF(font) {
 
   //create TTF buffer
 
-  var buf = ByteBuffer.prototype.create(bufSize);
+  var buf = ByteBuffer.create(bufSize);
 
   //special constants
   var entrySelector = Math.floor(Math.log(TABLES.length)/Math.LN2);
@@ -127,7 +129,7 @@ function generateTTF(font) {
   buf.writeUint16(rangeShift);
 
   _.forEach(TABLES, function (table) {
-    buf.writeUint32(table.innerName); //inner name
+    buf.writeUint32(utils.identifier(table.innerName)); //inner name
     buf.writeUint32(table.checkSum); //checksum
     buf.writeUint32(table.offset); //offset
     buf.writeUint32(table.length); //length
@@ -135,7 +137,7 @@ function generateTTF(font) {
 
   var headOffset = 0;
   _.forEach(_.sortBy(TABLES, 'order'), function (table) {
-    if (table.innerName === 0x68656164) { //we must store head offset to write font checksum
+    if (table.innerName === 'head') { //we must store head offset to write font checksum
       headOffset = buf.tell();
     }
     buf.writeBytes(table.buffer.buffer);

--- a/lib/ttf/tables/cmap.js
+++ b/lib/ttf/tables/cmap.js
@@ -5,200 +5,293 @@
 var _ = require('lodash');
 var ByteBuffer = require('../../byte_buffer.js');
 
-function getIDByUnicode(glyphs, unicode) {
-  var glyph = _.where(glyphs, { unicode : unicode });
-  return (glyph && glyph.length) ? glyph[0].id : 0;
-}
-
-// Delta is saved in signed int in cmap format 4 subtable, but can be in -0xFFFF..0 interval.
-// -0x10000..-0x7FFF values are stored with offset.
-function encodeDelta(delta) {
-  return delta > 0x7FFF ? delta - 0x10000 : (delta < -0x7FFF ? delta + 0x10000 : delta);
+function getIDByUnicode(font, unicode) {
+  return font.codePoints[unicode] ? font.codePoints[unicode].id : 0;
 }
 
 // Calculate character segments with non-interruptable chains of unicodes
-function getSegments(font, bound) {
-  var prevGlyph = null;
+function getSegments(font, bounds) {
+  bounds = bounds || Number.MAX_VALUE;
+
   var result = [];
-  var segment = {};
+  var segment;
 
-  var delta;
-  var prevEndCode = 0;
-  var prevDelta = -1;
-
-  _.forEach(font.glyphs, function (glyph) {
-    if (glyph.unicode === undefined) { // ignore glyphs with missed unicode
-      return;
+  // prevEndCode only changes when a segment closes
+  _.forEach(font.codePoints, function(glyph, unicode) {
+    unicode = parseInt(unicode, 10);
+    if (unicode >= bounds) {
+      return false;
     }
-    if (bound === undefined || glyph.unicode <= bound) {
-      // Initialize first segment or add new segment if code "hole" is found
-      if (prevGlyph === null || glyph.unicode !== prevGlyph.unicode + 1) {
-        if (prevGlyph !== null) {
-          segment.end = prevGlyph;
-          delta = prevEndCode - segment.start.unicode + prevDelta + 1;
-          segment.delta = encodeDelta(delta);
-          prevEndCode = segment.end.unicode;
-          prevDelta = delta;
-          result.push(segment);
-          segment = {};
-        }
-        segment.start = glyph;
+    // Initialize first segment or add new segment if code "hole" is found
+    if (!segment || unicode !== (segment.end + 1)) {
+      if (segment) {
+        result.push(segment);
       }
-      prevGlyph = glyph;
+      segment = {
+        start: unicode
+      };
     }
+    segment.end = unicode;
   });
 
   // Need to finish the last segment
-  if (prevGlyph !== null) {
-    segment.end = prevGlyph;
-    delta = prevEndCode - segment.start.unicode + prevDelta + 1;
-    segment.delta = delta > 0x7FFF ? delta - 0x10000 : (delta < -0x7FFF ? delta + 0x10000 : delta);
+  if (segment) {
     result.push(segment);
   }
+
+  _.forEach(result, function(segment) {
+    segment.length = segment.end - segment.start + 1;
+  });
+
   return result;
 }
 
-function writeSubTableHeader (buf, platformID, encodingID, offset) {
-  buf.writeUint16(platformID); // platform
-  buf.writeUint16(encodingID); // encoding
-  buf.writeUint32(offset); // offset
+// Returns an array of {unicode, glyph} sets for all valid code points up to bounds
+function getCodePoints(codePoints, bounds) {
+  bounds = bounds || Number.MAX_VALUE;
+  var result = [];
+    _.forEach(codePoints, function(glyph, unicode) {
+      unicode = parseInt(unicode, 10);
+      // Since this is a sparse array, iterating will only yield the valid code points
+      if(unicode > bounds) {
+        return false;
+      }
+      result.push({
+        unicode: unicode,
+        glyph: glyph
+      });
+    });
+    return result;
 }
 
-function createSubTable0(glyphs) {
-  var buf = ByteBuffer.prototype.create(262); //fixed bug size
+function bufferForTable(format, length) {
+  var fieldWidth = format === 8 || format === 10 || format === 12 || format === 13 ? 4 : 2;
+  length += (0
+    + fieldWidth // Format
+    + fieldWidth // Length
+    + fieldWidth // Language
+  );
+  var LANGUAGE = 0;
+  var buffer = ByteBuffer.create(length);
 
-  buf.writeUint16(0); // format
-  buf.writeUint16(262); // length
-  buf.writeUint16(0); // language
+  var writer = fieldWidth === 4 ? buffer.writeUint32 : buffer.writeUint16;
 
-  // Array of unicodes 0..255
-  var unicodes = _.pluck(_.filter(glyphs, function(glyph) {
-    return glyph.unicode !== undefined; // ignore glyphs with missed unicode
-  }), 'unicode');
+  // Format specifier
+  buffer.writeUint16(format);
+  if(fieldWidth === 4) {
+    // In case of formats 8.…, 10.…, 12.… and 13.…, this is the decimal part of the format number
+    // But since have not been any point releases, this can be zero in that case as well
+    buffer.writeUint16(0);
+  }
+  // Length
+  writer.call(buffer, length);
+  // Language code (0, only used for legacy quickdraw tables)
+  writer.call(buffer, LANGUAGE);
+  
+  return buffer;
+}
+
+function createFormat0Table(font) {
+  var FORMAT = 0;
 
   var i;
-  for (i = 0; i < 256; i++) {
-    buf.writeUint8(unicodes.indexOf(i) >= 0 ? getIDByUnicode(glyphs, i) : 0); // existing char in table 0..255
-  }
 
-  return buf;
+  var length = 0xff + 1; //Format 0 maps only single-byte code points
+
+  var buffer = bufferForTable(FORMAT, length);
+
+  for (i = 0; i < length; i++) {
+    buffer.writeUint8(getIDByUnicode(font, i)); // existing char in table 0..255
+  }
+  return buffer;
 }
 
-function createSubTable4(glyphs, segments2bytes) {
+function createFormat4Table(font) {
+  var FORMAT = 4;
 
-  var bufSize = 24; // subtable 4 header and required array elements
-  bufSize += segments2bytes.length * 8; // subtable 4 segments
-  var buf = ByteBuffer.prototype.create(bufSize); //fixed bug size
+  var i;
 
-  buf.writeUint16(4); // format
-  buf.writeUint16(bufSize); // length
-  buf.writeUint16(0); // language
-  var segCount = segments2bytes.length + 1;
-  buf.writeUint16(segCount * 2); // segCountX2
+  var segments = getSegments(font, 0xFFFF);
+  var glyphIndexArrays = [];
+
+  _.forEach(segments, function(segment) {
+    var glyphIndexArray = [];
+    for(var unicode = segment.start;unicode <= segment.end;unicode++) {
+      glyphIndexArray.push(getIDByUnicode(font, unicode));
+    }
+    glyphIndexArrays.push(glyphIndexArray);
+  });
+
+  var segCount = segments.length + 1; // + 1 for the 0xFFFF section
+  var glyphIndexArrayLength = _.reduce(_.pluck(glyphIndexArrays, 'length'), function(result, count) {return result + count;}, 0);
+
+  var length = (0
+    + 2 // segCountX2
+    + 2 // searchRange
+    + 2 // entrySelector
+    + 2 // rangeShift
+    + 2 * segCount // endCodes
+    + 2 // Padding
+    + 2 * segCount //startCodes
+    + 2 * segCount //idDeltas
+    + 2 * segCount //idRangeOffsets
+    + 2 * glyphIndexArrayLength
+  );
+
+  var buffer = bufferForTable(FORMAT, length);
+
+  buffer.writeUint16(segCount * 2); // segCountX2
   var maxExponent = Math.floor(Math.log(segCount)/Math.LN2);
   var searchRange = 2 * Math.pow(2, maxExponent);
-  buf.writeUint16(searchRange); // searchRange
-  buf.writeUint16(maxExponent); // entrySelector
-  buf.writeUint16(2 * segCount - searchRange); // rangeShift
+  buffer.writeUint16(searchRange); // searchRange
+  buffer.writeUint16(maxExponent); // entrySelector
+  buffer.writeUint16(2 * segCount - searchRange); // rangeShift
 
   // Array of end counts
-  _.forEach(segments2bytes, function (segment) {
-    buf.writeUint16(segment.end.unicode);
+  _.forEach(segments, function (segment) {
+    buffer.writeUint16(segment.end);
   });
-  buf.writeUint16(0xFFFF); // endCountArray should be finished with 0xFFFF
+  buffer.writeUint16(0xFFFF); // endCountArray should be finished with 0xFFFF
 
-  buf.writeUint16(0); // reservedPad
+  buffer.writeUint16(0); // reservedPad
 
   // Array of start counts
-  _.forEach(segments2bytes, function (segment) {
-    buf.writeUint16(segment.start.unicode); //startCountArray
+  _.forEach(segments, function (segment) {
+    buffer.writeUint16(segment.start); //startCountArray
   });
-  buf.writeUint16(0xFFFF); // startCountArray should be finished with 0xFFFF
+  buffer.writeUint16(0xFFFF); // startCountArray should be finished with 0xFFFF
 
-  // Array of deltas
-  _.forEach(segments2bytes, function (segment) {
-    buf.writeInt16(segment.delta); //startCountArray
-  });
-  buf.writeUint16(1); // idDeltaArray should be finished with 1
-
-  // Array of range offsets, it doesn't matter when deltas present, should be initialized with zeros
-  //It should also have additional 0 value
-  var i;
-  for (i = 0; i < segments2bytes.length; i++) {
-    buf.writeUint16(0);
+  // Array of deltas. Leave it zero to not complicate things when using the glyph index array
+  for (i = 0; i < segments.length; i++) {
+    buffer.writeUint16(0); // delta is always zero because we use the glyph array
   }
-  buf.writeUint16(0); // rangeOffsetArray should be finished with 0
+  buffer.writeUint16(1); // idDeltaArray should be finished with 1
 
-  //Array of glyph IDs should be written here, but it seem to be unuseful when deltas present, at least TTX tool doesn't
-  // write them. So we omit this array too.
+  // Array of range offsets
+  var offset = 0;
+  for (i = 0; i < segments.length; i++) {
+    buffer.writeUint16(2 * ((segments.length - i + 1) + offset));
+    offset += glyphIndexArrays[i].length;
+  }
+  buffer.writeUint16(0); // rangeOffsetArray should be finished with 0
 
-  return buf;
+  _.forEach(glyphIndexArrays, function(glyphIndexArray) {
+    _.forEach(glyphIndexArray, function(glyphId) {
+      buffer.writeUint16(glyphId);
+    });
+  });
+
+  return buffer;
 }
 
-function createSubTable12(segments4bytes) {
-  var bufSize = 16; // subtable 12 header
-  bufSize += segments4bytes ? (segments4bytes.length * 12) : 0; // subtable 12 segments
-  var buf = ByteBuffer.prototype.create(bufSize); //fixed bug size
+function createFormat12Table(font) {
+  var FORMAT = 12;
 
-  buf.writeUint16(12); // format
-  buf.writeUint16(0); // reserved
-  buf.writeUint32(bufSize); // length
-  buf.writeUint32(0); // language
-  buf.writeUint32(segments4bytes.length); // nGroups
-  var startGlyphCode = 0;
-  _.forEach(segments4bytes, function (segment) {
-    buf.writeUint32(segment.start.unicode); // startCharCode
-    buf.writeUint32(segment.end.unicode); // endCharCode
-    buf.writeUint32(startGlyphCode); // startGlyphCode
-    startGlyphCode += segment.end.unicode - segment.start.unicode + 1;
+  var codePoints = getCodePoints(font.codePoints);
+
+  var length = (0
+    + 4 // nGroups
+    + 4 * codePoints.length // startCharCode
+    + 4 * codePoints.length // endCharCode
+    + 4 * codePoints.length // startGlyphCode
+  );
+
+  var buffer = bufferForTable(FORMAT, length);
+
+  buffer.writeUint32(codePoints.length); // nGroups
+  _.forEach(codePoints, function (codePoint) {
+    buffer.writeUint32(codePoint.unicode); // startCharCode
+    buffer.writeUint32(codePoint.unicode); // endCharCode
+    buffer.writeUint32(codePoint.glyph.id); // startGlyphCode
   });
 
-  return buf;
+  return buffer;
 }
 
 function createCMapTable(font) {
+  var TABLE_HEAD = (0
+    + 2 // platform
+    + 2 // encoding
+    + 4 // offset
+  );
 
-  //we will always have subtable 4
-  var segments2bytes = getSegments(font, 0xFFFF); //get segments for unicodes < 0xFFFF if found unicodes >= 0xFF
+  var singleByteTable = createFormat0Table(font);
+  var twoByteTable = createFormat4Table(font);
+  var fourByteTable = createFormat12Table(font);
 
-  // We need subtable 12 only if found unicodes with > 2 bytes.
-  var hasGLyphsOver2Bytes = _.find(font.glyphs, function(glyph) {
-    return glyph.unicode > 0xFFFF;
+  // Subtable headers must be sorted by platformID, encodingID
+  var tableHeaders = [
+    // subtable 4, unicode
+    {
+      platformID: 0,
+      encodingID: 3,
+      table: twoByteTable
+    },
+    // subtable 12, unicode
+    {
+      platformID: 0,
+      encodingID: 4,
+      table: fourByteTable
+    },
+    // subtable 0, mac standard
+    {
+      platformID: 1,
+      encodingID: 0,
+      table: singleByteTable
+    },
+    // subtable 4, windows standard, identical to the unicode table
+    {
+      platformID: 3,
+      encodingID: 1,
+      table: twoByteTable
+    },
+    // subtable 12, windows ucs4
+    {
+      platformID: 3,
+      encodingID: 10,
+      table: fourByteTable
+    }
+  ];
+
+  var tables = [
+    twoByteTable,
+    singleByteTable,
+    fourByteTable
+  ];
+
+  var tableOffset = (0
+    + 2 // version
+    + 2 // number of subtable headers
+    + tableHeaders.length * TABLE_HEAD
+  );
+
+  // Calculate offsets for each table
+  _.forEach(tables, function(table) {
+    table._tableOffset = tableOffset;
+    tableOffset += table.length;
   });
 
-  var segments4bytes = hasGLyphsOver2Bytes ? getSegments(font) : null; //get segments for all unicodes
+  var length = tableOffset;
 
-  // Create subtables first.
-  var subTable0 = createSubTable0(font.glyphs); // subtable 0
-  var subTable4 = createSubTable4(font.glyphs, segments2bytes); // subtable 4
-  var subTable12 = segments4bytes ? createSubTable12(segments4bytes) : null; // subtable 12
-
-  // Calculate bufsize
-  var subTableOffset = 4 + (subTable12 ? 32 : 24);
-  var bufSize = subTableOffset + subTable0.length + subTable4.length + (subTable12 ? subTable12.length : 0);
-
-  var buf = ByteBuffer.prototype.create(bufSize);
+  var buffer = ByteBuffer.create(length);
 
   // Write table header.
-  buf.writeUint16(0); // version
-  buf.writeUint16(segments4bytes ? 4 : 3); // count
+  buffer.writeUint16(0); // version
+  buffer.writeUint16(tableHeaders.length); // count
 
-  // Create subtable headers. Subtables must be sorted by platformID, encodingID
-  writeSubTableHeader(buf, 0, 3, subTableOffset); // subtable 4, unicode
-  writeSubTableHeader(buf, 1, 0, subTableOffset + subTable4.length); // subtable 0, mac standard
-  writeSubTableHeader(buf, 3, 1, subTableOffset); // subtable 4, windows standard
-  if (subTable12) {
-    writeSubTableHeader(buf, 3, 10, subTableOffset + subTable0.length + subTable4.length); // subtable 12
-  }
+  // Write subtable headers
+  _.forEach(tableHeaders, function(header) {
+    buffer.writeUint16(header.platformID); // platform
+    buffer.writeUint16(header.encodingID); // encoding
+    buffer.writeUint32(header.table._tableOffset); // offset
+  });
 
-  // Write tables, order of table seem to be magic, it is taken from TTX tool
-  buf.writeBytes(subTable4.buffer);
-  buf.writeBytes(subTable0.buffer);
-  if (subTable12) {
-    buf.writeBytes(subTable12.buffer);
-  }
+  // Write subtables
+  _.forEach(tables, function(table) {
+    buffer.writeBytes(table.buffer);
+  });
 
-  return buf;
+  return buffer;
 }
 
 module.exports = createCMapTable;

--- a/lib/ttf/tables/glyf.js
+++ b/lib/ttf/tables/glyf.js
@@ -77,8 +77,8 @@ function compactCoords(coords) {
 
 //calculates length of glyph data in GLYF table
 function glyphDataSize(glyph) {
-
-  if (!glyph.contours.length) {
+  // Ignore glyphs without outlines. These will get a length of zero in the “loca” table
+  if(!glyph.contours.length) {
     return 0;
   }
 
@@ -125,11 +125,12 @@ function createGlyfTable(font) {
     glyph.ttf_y = compactCoords(glyph.ttf_y);
   });
 
-  var buf = ByteBuffer.prototype.create(tableSize(font));
+  var buf = ByteBuffer.create(tableSize(font));
 
   _.forEach(font.glyphs, function (glyph) {
 
-    if (!glyph.contours.length) {
+    // Ignore glyphs without outlines. These will get a length of zero in the “loca” table
+    if(!glyph.contours.length) {
       return;
     }
 

--- a/lib/ttf/tables/gsub.js
+++ b/lib/ttf/tables/gsub.js
@@ -1,0 +1,355 @@
+'use strict';
+
+// See documentation here: http://www.microsoft.com/typography/otspec/GSUB.htm
+
+var _ = require('lodash');
+var identifier = require('../utils.js').identifier;
+var ByteBuffer = require('../../byte_buffer.js');
+
+
+function createScriptList() {
+  var header = (0
+    + 2 // Script count
+    + 4 // Tag[0]
+    + 2 // Offset[0]
+  );
+
+  var scriptRecord = (0
+    + 2 // Script[0] DefaultLangSys Offset
+    + 2 // Script[0] LangSysCount (0)
+  );
+
+  var langSys = (0
+    + 2 // Script[0] DefaultLangSys LookupOrder
+    + 2 // Script[0] DefaultLangSys ReqFeatureIndex
+    + 2 // Script[0] DefaultLangSys FeatureCount (0?)
+    + 2 // Script[0] Optional Feature Index[0]
+  );
+
+  var length = (0
+    + header
+    + scriptRecord
+    + langSys
+  );
+
+  var buffer = ByteBuffer.create(length);
+
+  // Script count
+  buffer.writeUint16(1);
+  // Script identifier DFLT
+  buffer.writeUint32(identifier('DFLT'));
+  // Offset to the ScriptRecord
+  buffer.writeUint16(header);
+
+  // Script Record
+  // Offset to the start of langSys from the start of scriptRecord
+  buffer.writeUint16(scriptRecord); // DefaultLangSys
+  // Number of LangSys entries other than the default
+  buffer.writeUint16(0);
+
+  // LangSys record
+  // LookupOrder
+  buffer.writeUint16(0);
+  // ReqFeatureIndex -> only one required feature: all ligatures
+  buffer.writeUint16(0);
+  // Number of FeatureIndex values for this language system (excludes the required feature)
+  buffer.writeUint16(1);
+  // FeatureIndex for the first optional feature
+	// Note: Adding the same feature to both the optional
+	// and the required features is a clear violation of the spec
+	// but it fixes IE not displaying the ligatures.
+	// See http://partners.adobe.com/public/developer/opentype/index_table_formats.html, Section “Language System Table”
+	// “FeatureCount: Number of FeatureIndex values for this language system-*excludes the required feature*” (emphasis added)
+  buffer.writeUint16(0);
+
+  return buffer;
+}
+
+// Write one feature containing all ligatures
+function createFeatureList() {
+  var header = (0
+    + 2 // FeatureCount
+    + 4 // FeatureTag[0]
+    + 2 // Feature Offset[0]
+  );
+
+  var length = (0
+    + header
+    + 2 // FeatureParams[0]
+    + 2 // LookupCount[0]
+    + 2 // Lookup[0] LookupListIndex[0]
+  );
+
+  var buffer = ByteBuffer.create(length);
+  // FeatureCount
+  buffer.writeUint16(1);
+  // FeatureTag[0]
+  buffer.writeUint32(identifier('liga'));
+  // Feature Offset[0]
+  buffer.writeUint16(header);
+  // FeatureParams[0]
+  buffer.writeUint16(0);
+  // LookupCount[0]
+  buffer.writeUint16(1);
+  // Index into lookup table. Since we only have ligatures, the index is always 0
+  buffer.writeUint16(0);
+
+  return buffer;
+}
+
+function createLigatureCoverage(font, ligatureGroups) {
+  var glyphCount = ligatureGroups.length;
+
+  var length = (0
+    + 2 // CoverageFormat
+    + 2 // GlyphCount
+    + 2 * glyphCount // GlyphID[i]
+  );
+
+  var buffer = ByteBuffer.create(length);
+
+  // CoverageFormat
+  buffer.writeUint16(1);
+
+  // Length
+  buffer.writeUint16(glyphCount);
+
+
+  _.forEach(ligatureGroups, function(group) {
+    buffer.writeUint16(group.startGlyph.id);
+  });
+
+  return buffer;
+}
+
+function createLigatureTable(font, ligature) {
+  var allCodePoints = font.codePoints;
+
+  var unicode = ligature.unicode;
+
+  var length = (0
+    + 2 // LigGlyph
+    + 2 // CompCount
+    + 2 * (unicode.length - 1)
+  );
+
+  var buffer = ByteBuffer.create(length);
+
+  // LigGlyph
+  var glyph = ligature.glyph;
+  buffer.writeUint16(glyph.id);
+
+  // CompCount
+  buffer.writeUint16(unicode.length);
+
+  // Compound glyphs (excluding first as it’s already in the coverage table)
+  for(var i=1;i<unicode.length;i++) {
+    glyph = allCodePoints[unicode[i]];
+    buffer.writeUint16(glyph.id);
+  }
+
+  return buffer;
+}
+
+function createLigatureSet(font, codePoint, ligatures) {
+  var ligatureTables = [];
+  _.forEach(ligatures, function(ligature) {
+  	ligatureTables.push(createLigatureTable(font, ligature));
+  });
+
+  var tableLengths = _.reduce(_.pluck(ligatureTables, 'length'), function(result, count) {return result + count;}, 0);
+
+  var offset = (0
+    + 2 // LigatureCount
+    + 2 * ligatures.length
+  );
+
+  var length = (0
+    + offset
+    + tableLengths
+  );
+
+  var buffer = ByteBuffer.create(length);
+
+  // LigatureCount
+  buffer.writeUint16(ligatures.length);
+
+  // Ligature offsets
+  _.forEach(ligatureTables, function(table) {
+    // The offset to the current set, from SubstFormat
+    buffer.writeUint16(offset);
+    offset += table.length;
+  });
+
+  // Ligatures
+  _.forEach(ligatureTables, function(table) {
+    buffer.writeBytes(table.buffer);
+  });
+
+  return buffer;
+}
+
+function createLigatureList(font, ligatureGroups) {
+  var sets = [];
+  _.forEach(ligatureGroups, function(group) {
+    var set = createLigatureSet(font, group.codePoint, group.ligatures);
+    sets.push(set);
+  });
+
+  var setLengths = _.reduce(_.pluck(sets, 'length'), function(result, count) {return result + count;}, 0);
+
+  var coverage = createLigatureCoverage(font, ligatureGroups);
+
+  var tableOffset = (0
+    + 2 // Lookup type
+    + 2 // Lokup flag
+    + 2 // SubTableCount
+    + 2 // SubTable[0] Offset
+  );
+
+  var setOffset = (0
+    + 2 // SubstFormat
+    + 2 // Coverage offset
+    + 2 // LigSetCount
+    + 2 * sets.length // LigSet Offsets
+  );
+
+  var coverageOffset = setOffset + setLengths;
+
+  var length = (0
+    + tableOffset
+    + coverageOffset
+    + coverage.length
+  );
+
+  var buffer = ByteBuffer.create(length);
+
+  // Lookup type 4 – ligatures
+  buffer.writeUint16(4);
+
+  // Lookup flag – empty
+  buffer.writeUint16(0);
+
+  // Subtable count
+  buffer.writeUint16(1);
+
+  // Subtable[0] offset
+  buffer.writeUint16(tableOffset);
+
+  // SubstFormat
+  buffer.writeUint16(1);
+
+  // Coverage
+  buffer.writeUint16(coverageOffset);
+
+  // LigSetCount
+  buffer.writeUint16(sets.length);
+
+  _.forEach(sets, function(set) {
+    // The offset to the current set, from SubstFormat
+    buffer.writeUint16(setOffset);
+    setOffset += set.length;
+  });
+
+  _.forEach(sets, function(set) {
+    buffer.writeBytes(set.buffer);
+  });
+
+  buffer.writeBytes(coverage.buffer);
+
+  return buffer;
+}
+
+// Add a lookup for each ligature
+function createLookupList(font) {
+  var ligatures = font.ligatures;
+
+  var groupedLigatures = {};
+
+  // Group ligatures by first code point
+  _.forEach(ligatures, function(ligature) {
+    var first = ligature.unicode[0];
+    if(!_.has(groupedLigatures, first)) {
+      groupedLigatures[first] = [];
+    }
+    groupedLigatures[first].push(ligature);
+  });
+
+  var ligatureGroups = [];
+  _.forEach(groupedLigatures, function(ligatures, codePoint) {
+    codePoint = parseInt(codePoint, 10);
+    ligatureGroups.push({
+      codePoint: codePoint,
+      ligatures: ligatures,
+      startGlyph: font.codePoints[codePoint]
+    });
+  });
+
+  ligatureGroups.sort(function(a, b) {
+    return a.startGlyph.id - b.startGlyph.id;
+  });
+
+  var offset = (0
+    + 2 // Lookup count
+    + 2 // Lookup[0] offset
+  );
+
+  var set = createLigatureList(font, ligatureGroups);
+
+  var length = (0
+    + offset
+    + set.length
+  );
+
+  var buffer = ByteBuffer.create(length);
+
+  // Lookup count
+  buffer.writeUint16(1);
+
+  // Lookup[0] offset
+  buffer.writeUint16(offset);
+
+  // Lookup[0]
+  buffer.writeBytes(set.buffer);
+
+  return buffer;
+}
+
+function createGSUB(font) {
+  var scriptList = createScriptList();
+  var featureList = createFeatureList();
+  var lookupList = createLookupList(font);
+
+  var lists = [scriptList, featureList, lookupList];
+
+  var offset = (0
+    + 4 // Version
+    + 2 * lists.length // List offsets
+  );
+
+  // Calculate offsets
+  _.forEach(lists, function(list) {
+    list._listOffset = offset;
+    offset += list.length;
+  });
+
+  var length = offset;
+  var buffer = ByteBuffer.create(length);
+ 
+  // Version
+  buffer.writeUint32(0x00010000);
+
+  // Offsets
+  _.forEach(lists, function(list) {
+    buffer.writeUint16(list._listOffset);
+  });
+
+  // List contents
+  _.forEach(lists, function(list) {
+    buffer.writeBytes(list.buffer);
+  });
+
+  return buffer;
+}
+
+module.exports = createGSUB;

--- a/lib/ttf/tables/head.js
+++ b/lib/ttf/tables/head.js
@@ -11,7 +11,7 @@ function dateToUInt64(date) {
 
 function createHeadTable(font) {
 
-  var buf = ByteBuffer.prototype.create(54); // fixed table length
+  var buf = ByteBuffer.create(54); // fixed table length
 
   buf.writeInt32(0x10000); // version
   buf.writeInt32(font.revision * 0x10000); // fontRevision

--- a/lib/ttf/tables/hhea.js
+++ b/lib/ttf/tables/hhea.js
@@ -6,7 +6,7 @@ var ByteBuffer = require('../../byte_buffer.js');
 
 function createHHeadTable(font) {
 
-  var buf = ByteBuffer.prototype.create(36); // fixed table length
+  var buf = ByteBuffer.create(36); // fixed table length
 
   buf.writeInt32(0x10000); // version
   buf.writeInt16(font.ascent); // ascent

--- a/lib/ttf/tables/hmtx.js
+++ b/lib/ttf/tables/hmtx.js
@@ -7,7 +7,7 @@ var ByteBuffer = require('../../byte_buffer.js');
 
 function createHtmxTable(font) {
 
-  var buf = ByteBuffer.prototype.create(font.glyphs.length * 4);
+  var buf = ByteBuffer.create(font.glyphs.length * 4);
 
   _.forEach(font.glyphs, function (glyph) {
     buf.writeUint16(glyph.width); //advanceWidth

--- a/lib/ttf/tables/loca.js
+++ b/lib/ttf/tables/loca.js
@@ -14,7 +14,7 @@ function createLocaTable(font) {
 
   var isShortFormat = font.ttf_glyph_size < 0x20000;
 
-  var buf = ByteBuffer.prototype.create(tableSize(font, isShortFormat));
+  var buf = ByteBuffer.create(tableSize(font, isShortFormat));
 
   var location = 0;
   // Array of offsets in GLYF table for each glyph

--- a/lib/ttf/tables/maxp.js
+++ b/lib/ttf/tables/maxp.js
@@ -20,7 +20,7 @@ function getMaxContours(font) {
 
 function createMaxpTable(font) {
 
-  var buf = ByteBuffer.prototype.create(32);
+  var buf = ByteBuffer.create(32);
 
   buf.writeInt32(0x10000); // version
   buf.writeUint16(font.glyphs.length); // numGlyphs

--- a/lib/ttf/tables/name.js
+++ b/lib/ttf/tables/name.js
@@ -67,7 +67,7 @@ function createNameTable(font) {
 
   var names = getNames(font);
 
-  var buf = ByteBuffer.prototype.create(tableSize(names));
+  var buf = ByteBuffer.create(tableSize(names));
 
   buf.writeUint16(0); // formatSelector
   buf.writeUint16(names.length); // nameRecordsCount

--- a/lib/ttf/tables/os2.js
+++ b/lib/ttf/tables/os2.js
@@ -3,33 +3,26 @@
 // See documentation here: http://www.microsoft.com/typography/otspec/os2.htm
 
 var _ = require('lodash');
+var identifier = require('../utils.js').identifier;
 var ByteBuffer = require('../../byte_buffer.js');
 
 //get first glyph unicode
 function getFirstCharIndex(font) {
-  var minGlyph = _.min(font.glyphs, function(glyph) {
-    return (glyph.unicode === 0) ? 0xFFFF : (glyph.unicode || 0);
-  });
-  if (minGlyph) {
-    return minGlyph.unicode > 0xFFFF ? 0xFFFF : (minGlyph.unicode || 0);
-  } else {
-    return 0xFFFF;
-  }
+  return Math.max(0, Math.min(0xffff, Math.abs(_.min(Object.keys(font.codePoints), function(point) {
+    return parseInt(point, 10);
+  }))));
 }
 
 //get last glyph unicode
 function getLastCharIndex(font) {
-  var maxGlyph = _.max(font.glyphs, 'unicode');
-  if (maxGlyph) {
-    return maxGlyph.unicode > 0xFFFF ? 0xFFFF : (maxGlyph.unicode || 0);
-  } else {
-    return 0xFFFF;
-  }
+  return Math.max(0, Math.min(0xffff, Math.abs(_.max(Object.keys(font.codePoints), function(point) {
+    return parseInt(point, 10);
+  }))));
 }
 
 function createOS2Table(font) {
 
-  var buf = ByteBuffer.prototype.create(86);
+  var buf = ByteBuffer.create(86);
 
   buf.writeUint16(1); //version
   buf.writeInt16(font.avgWidth); // xAvgCharWidth
@@ -62,7 +55,7 @@ function createOS2Table(font) {
   buf.writeUint32(0); // ulUnicodeRange2
   buf.writeUint32(0); // ulUnicodeRange3
   buf.writeUint32(0); // ulUnicodeRange4
-  buf.writeUint32(0x50664564); // achVendID, equal to PfEd
+  buf.writeUint32(identifier('PfEd')); // achVendID, equal to PfEd
   buf.writeUint16(font.fsSelection); // fsSelection
   buf.writeUint16(getFirstCharIndex(font)); // usFirstCharIndex
   buf.writeUint16(getLastCharIndex(font)); // usLastCharIndex

--- a/lib/ttf/tables/post.js
+++ b/lib/ttf/tables/post.js
@@ -35,7 +35,7 @@ function createPostTable(font) {
     }
   });
 
-  var buf = ByteBuffer.prototype.create(tableSize(font, names));
+  var buf = ByteBuffer.create(tableSize(font, names));
 
   buf.writeInt32(0x20000); // formatType,  version 2.0
   buf.writeInt32(font.italicAngle); // italicAngle

--- a/lib/ttf/utils.js
+++ b/lib/ttf/utils.js
@@ -103,9 +103,22 @@ function toRelative(contours) {
   return resContours;
 }
 
+function identifier(string, littleEndian) {
+  var result = 0;
+  for(var i=0;i<string.length;i++) {
+    /*jshint bitwise:false*/
+    result = result << 8;
+    var index = littleEndian ? string.length - i - 1 : i;
+    result += string.charCodeAt(index);
+  }
+
+  return result;
+}
+
 module.exports.interpolate = interpolate;
 module.exports.simplify = simplify;
 module.exports.roundPoints = roundPoints;
 module.exports.removeClosingReturnPoints = removeClosingReturnPoints;
 module.exports.toRelative = toRelative;
+module.exports.identifier = identifier;
 

--- a/lib/ucs2.js
+++ b/lib/ucs2.js
@@ -1,0 +1,50 @@
+'use strict';
+
+var _ = require('lodash');
+
+// Taken from the punycode library
+function ucs2encode(array) {
+  return _.map(array, function(value) {
+    var output = '';
+    if (value > 0xFFFF) {
+      value -= 0x10000;
+      /*jshint bitwise: false*/
+      output += String.fromCharCode(value >>> 10 & 0x3FF | 0xD800);
+      value = 0xDC00 | value & 0x3FF;
+    }
+    output += String.fromCharCode(value);
+    return output;
+  }).join('');
+}
+
+function ucs2decode(string) {
+  var output = [],
+    counter = 0,
+    length = string.length,
+    value,
+    extra;
+  while (counter < length) {
+    value = string.charCodeAt(counter++);
+    if (value >= 0xD800 && value <= 0xDBFF && counter < length) {
+      // high surrogate, and there is a next character
+      extra = string.charCodeAt(counter++);
+      /*jshint bitwise: false*/
+      if ((extra & 0xFC00) === 0xDC00) { // low surrogate
+        output.push(((value & 0x3FF) << 10) + (extra & 0x3FF) + 0x10000);
+      } else {
+        // unmatched surrogate; only append this code unit, in case the next
+        // code unit is the high surrogate of a surrogate pair
+        output.push(value);
+        counter--;
+      }
+    } else {
+      output.push(value);
+    }
+  }
+  return output;
+}
+
+module.exports = {
+  encode: ucs2encode,
+  decode: ucs2decode
+};


### PR DESCRIPTION
I’ve modified the code to read ligature glyphs from the SVG font and write them to the GSUB table of the output file.

As a side-effect, glyphs are now de-duplicated as there isn’t a one-to-one mapping anymore between glyphs and unicode code points.