### PR TITLE
Allowing zero-width glyph

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,8 +49,8 @@ function svg2ttf(svgString, options) {
     glyph.unicode = svgGlyph.unicode;
     glyph.name = svgGlyph.name;
     glyph.d = svgGlyph.d;
-    glyph.height = svgGlyph.height || font.height;
-    glyph.width = svgGlyph.width || font.width;
+    glyph.height = !isNaN(svgGlyph.height) ? svgGlyph.height : font.height;
+    glyph.width = !isNaN(svgGlyph.width) ? svgGlyph.width : font.width;
     glyphs.push(glyph);
   });
 
@@ -65,8 +65,8 @@ function svg2ttf(svgString, options) {
     missingGlyph = new sfnt.Glyph();
     missingGlyph.unicode = 0;
     missingGlyph.d = svgFont.missingGlyph.d;
-    missingGlyph.height = svgFont.missingGlyph.height || font.height;
-    missingGlyph.width = svgFont.missingGlyph.width || font.width;
+    missingGlyph.height = !isNaN(svgFont.missingGlyph.height) ? svgFont.missingGlyph.height : font.height;
+    missingGlyph.width = !isNaN(svgFont.missingGlyph.width) ? svgFont.missingGlyph.width : font.width;
     glyphs.push(missingGlyph);
 
     if (notDefGlyph) { //duplicate definition, we need to remove .notdef glyph


### PR DESCRIPTION
Allowing zero-width glyph (including the missing glyph). Otherwise zero-width glyphs will be extended to `font.width`.

To enable some width-detecting tricks such as [houkanshan/fontonload](https://github.com/houkanshan/fontonload), who used a zero-width U+FFFD glyph to detect if the Web Font file is loaded.