### PR TITLE
Order longer ligatures first

### DIFF
--- a/lib/ttf/tables/cmap.js
+++ b/lib/ttf/tables/cmap.js
@@ -229,35 +229,35 @@ function createCMapTable(font) {
   // Subtable headers must be sorted by platformID, encodingID
   var tableHeaders = [
     // subtable 4, unicode
-      {
-        platformID: 0,
-        encodingID: 3,
-        table: twoByteTable
-      },
+    {
+      platformID: 0,
+      encodingID: 3,
+      table: twoByteTable
+    },
     // subtable 12, unicode
-      {
-        platformID: 0,
-        encodingID: 4,
-        table: fourByteTable
-      },
+    {
+      platformID: 0,
+      encodingID: 4,
+      table: fourByteTable
+    },
     // subtable 0, mac standard
-      {
-        platformID: 1,
-        encodingID: 0,
-        table: singleByteTable
-      },
+    {
+      platformID: 1,
+      encodingID: 0,
+      table: singleByteTable
+    },
     // subtable 4, windows standard, identical to the unicode table
-      {
-        platformID: 3,
-        encodingID: 1,
-        table: twoByteTable
-      },
+    {
+      platformID: 3,
+      encodingID: 1,
+      table: twoByteTable
+    },
     // subtable 12, windows ucs4
-      {
-        platformID: 3,
-        encodingID: 10,
-        table: fourByteTable
-      }
+    {
+      platformID: 3,
+      encodingID: 10,
+      table: fourByteTable
+    }
   ];
 
   var tables = [

--- a/lib/ttf/tables/gsub.js
+++ b/lib/ttf/tables/gsub.js
@@ -285,6 +285,12 @@ function createLookupList(font) {
 
   _.forEach(groupedLigatures, function (ligatures, codePoint) {
     codePoint = parseInt(codePoint, 10);
+    // Order ligatures by length, descending
+    // “Ligatures with more components must be stored ahead of those with fewer components in order to be found”
+    // From: http://partners.adobe.com/public/developer/opentype/index_tag7.html#liga
+    ligatures.sort(function(ligA, ligB) {
+      return ligB.unicode.length - ligA.unicode.length;
+    });
     ligatureGroups.push({
       codePoint: codePoint,
       ligatures: ligatures,

--- a/lib/ttf/tables/gsub.js
+++ b/lib/ttf/tables/gsub.js
@@ -288,7 +288,7 @@ function createLookupList(font) {
     // Order ligatures by length, descending
     // “Ligatures with more components must be stored ahead of those with fewer components in order to be found”
     // From: http://partners.adobe.com/public/developer/opentype/index_tag7.html#liga
-    ligatures.sort(function(ligA, ligB) {
+    ligatures.sort(function (ligA, ligB) {
       return ligB.unicode.length - ligA.unicode.length;
     });
     ligatureGroups.push({


### PR DESCRIPTION
It seems I have missed some specifications when I first implemented ligatures.


http://partners.adobe.com/public/developer/opentype/index_tag7.html#liga has this to say:

	Recommended implementation:
	The liga table maps sequences of glyphs to corresponding
	ligatures (GSUB lookup type 4).
	Ligatures with more components must be
	stored ahead of those with fewer components
	in order to be found.
	[…]

This change puts longer glyph sequences ahead of shorter ones