### PR TITLE
Allowing custom ttf font version string

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ API
 - `options`
   - `copyright` - copyright string (optional)
   - `ts` - Unix timestamp (in seconds) to override creation time (optional)
+  - `version` - TTF Font Version as a string formatted as 'Version x.y' or object
+     - `major` - Defaults to 1
+     - `minor` - Defaults to 0
+     - `suffix` - Defaults to null
 - `buf` - internal [byte buffer](https://github.com/fontello/microbuffer)
    object, similar to DataView. It's `buffer` property is  `Uin8Array` or `Array`
    with ttf content.

--- a/index.js
+++ b/index.js
@@ -18,13 +18,39 @@ function svg2ttf(svgString, options) {
   var svgFont = svg.load(svgString);
 
   options = options || {};
+  options.version = options.version || {
+    major: 1,
+    minor: 0,
+    suffix: null
+  };
+
+  function generateTTFVersionString(options) {
+    if (_.isString(options.version)) {
+      var versionRegEx = /(?:Version)\s+(\d)\.(\d)[;\.\-]?(.*)/gi;
+      var versionMatch;
+
+      if (((versionMatch = versionRegEx.exec(options.version)) !== null)) {
+        options.version = {
+          major: versionMatch[1],
+          minor: versionMatch[2],
+          suffix: versionMatch[3]
+        };
+      } else {
+        throw 'Invalid version string ' + options.version;
+      }
+
+    }
+    return 'Version ' +
+      (options.version.major || 1) + '.' + (options.version.minor || 0) +
+      (options.version.suffix ? '; ' + options.version.suffix : '');
+  }
 
   font.id = options.id || svgFont.id;
   font.familyName = options.familyname || svgFont.familyName || svgFont.id;
   font.copyright = options.copyright || svgFont.metadata;
   font.sfntNames.push({ id: 2, value: options.subfamilyname || 'Regular' }); // subfamily name
   font.sfntNames.push({ id: 4, value: options.fullname || svgFont.id }); // full name
-  font.sfntNames.push({ id: 5, value: 'Version 1.0' }); // version ID for TTF name table
+  font.sfntNames.push({ id: 5, value: generateTTFVersionString(options) }); // version ID for TTF name table
   font.sfntNames.push({ id: 6, value: options.fullname || svgFont.id }); // Postscript name for the font, required for OSX Font Book
 
   if (typeof options.ts !== 'undefined') {

--- a/svg2ttf.js
+++ b/svg2ttf.js
@@ -40,6 +40,46 @@ parser.addArgument(
 );
 
 parser.addArgument(
+  [ '--v', '--font-version' ],
+  {
+    help: 'Version',
+    required: false,
+    dest: 'version'
+  }
+);
+
+parser.addArgument(
+  [ '--vma', '--version-major' ],
+  {
+    help: 'Major Version',
+    required: false,
+    defaultValue: 1,
+    type: 'int',
+    dest: 'versionMajor'
+  }
+);
+
+parser.addArgument(
+  [ '--vmi', '--version-minor' ],
+  {
+    help: 'Minor Version',
+    required: false,
+    defaultValue: 0,
+    type: 'int',
+    dest: 'versionMinor'
+  }
+);
+
+parser.addArgument(
+  [ '--vs', '--version-suffix' ],
+  {
+    help: 'Other Version Info',
+    required: false,
+    dest: 'versionSuffix'
+  }
+);
+
+parser.addArgument(
   [ 'infile' ],
   {
     nargs: 1,
@@ -70,6 +110,22 @@ try {
 if (args.copyright) {
   options.copyright = args.copyright;
 }
+if (args.version) {
+  options.version = args.version;
+} else if (args.versionMajor) {
+  options.version = {
+    major: args.versionMajor,
+    minor: 0,
+    suffix: null
+  };
+  if (args.versionMinor) {
+    options.version.minor = args.versionMinor;
+  }
+  if (args.versionSuffix) {
+    options.version.suffix = args.versionSuffix;
+  }
+}
+
 
 if (args.ts !== null) {
   options.ts = args.ts;


### PR DESCRIPTION
Addresses issue #49
Add support for custom version strings as long as the meet the TTF standard.
 - Can handle major, minor and custom string as an object, or a correctly formatted string.
 - Checks correctness of passed string.
 - Adds flags to command line use to support font version.

Closes #49 