### PR TITLE
quickfix for inkscape fonts

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,8 @@ function svg2ttf(svgString, options) {
 
   options = options || {};
 
-  font.id = options.id || svgFont.id;
+  font.id = svgFont.familyName || options.id || svgFont.id;
+	svgFont.id = font.id;
   font.familyName = options.familyname || svgFont.familyName || svgFont.id;
   font.copyright = options.copyright || svgFont.metadata;
   font.sfntNames.push({ id: 2, value: options.subfamilyname || svgFont.subfamilyName || 'Regular' }); // subfamily name

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ function svg2ttf(svgString, options) {
   options = options || {};
 
   font.id = svgFont.familyName || options.id || svgFont.id;
-	svgFont.id = font.id;
+  svgFont.id = font.id;
   font.familyName = options.familyname || svgFont.familyName || svgFont.id;
   font.copyright = options.copyright || svgFont.metadata;
   font.sfntNames.push({ id: 2, value: options.subfamilyname || svgFont.subfamilyName || 'Regular' }); // subfamily name


### PR DESCRIPTION
Basically if you are creating fonts with Inkscape, they will always have the same name and you won't be able to install more than one font which you created locally. With this fix you can rename the fonts. 
[ the .ttf font-name will become the .svg file-name ]