### PR TITLE
Keep underline-thickness and underline-position attributes

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,6 +62,13 @@ function svg2ttf(svgString, options) {
   font.descent  = !isNaN(svgFont.descent) ? svgFont.descent : -font.vertOriginY;
   font.ascent   = svgFont.ascent || (font.unitsPerEm - font.vertOriginY);
 
+  if (svgFont.underlinePosition) {
+    font.underlinePosition = svgFont.underlinePosition;
+  }
+  if (svgFont.underlineThickness) {
+    font.underlineThickness = svgFont.underlineThickness;
+  }
+
   var glyphs = font.glyphs;
   var codePoints = font.codePoints;
   var ligatures = font.ligatures;

--- a/index.js
+++ b/index.js
@@ -62,10 +62,10 @@ function svg2ttf(svgString, options) {
   font.descent  = !isNaN(svgFont.descent) ? svgFont.descent : -font.vertOriginY;
   font.ascent   = svgFont.ascent || (font.unitsPerEm - font.vertOriginY);
 
-  if (svgFont.underlinePosition) {
+  if (typeof svgFont.underlinePosition !== 'undefined') {
     font.underlinePosition = svgFont.underlinePosition;
   }
-  if (svgFont.underlineThickness) {
+  if (typeof svgFont.underlineThickness !== 'undefined') {
     font.underlineThickness = svgFont.underlineThickness;
   }
 

--- a/lib/svg.js
+++ b/lib/svg.js
@@ -110,7 +110,9 @@ function load(str) {
   attrs = {
     ascent:     'ascent',
     descent:    'descent',
-    unitsPerEm: 'units-per-em'
+    unitsPerEm: 'units-per-em',
+    underlineThickness: 'underline-thickness',
+    underlinePosition:  'underline-position'
   };
   _.forEach(attrs, function (val, key) {
     if (fontFaceElem.hasAttribute(val)) { font[key] = parseInt(fontFaceElem.getAttribute(val), 10); }


### PR DESCRIPTION
Fixes https://github.com/fontello/svg2ttf/issues/79

TTF generator already supported underline attributes, SVG parser didn't. With this fix attributes are passed to TTF if they are set.