### PR TITLE
Way to opt for using typo metrics in icon-font

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,6 +48,10 @@ function svg2ttf(svgString, options) {
     font.createdDate = font.modifiedDate = new Date(parseInt(options.ts, 10) * 1000);
   }
 
+  if (options.useTypoMetrics) {
+    font.fsSelection = 0xC0;
+  }
+
   // Try to fill font metrics or guess defaults
   //
   font.unitsPerEm   = svgFont.unitsPerEm || 1000;


### PR DESCRIPTION
Add feature: https://github.com/fontello/svg2ttf/issues/95
Fixes: https://github.com/fontello/svg2ttf/issues/48

this changes the fsSelection value from `0x40` (`100000`) to `0xC0` (`11000000`)
if `useTypoMetrics` options is set to `true`