### PR TITLE
feat: change the OS/2 table version to 4

### DIFF
--- a/lib/ttf/tables/os2.js
+++ b/lib/ttf/tables/os2.js
@@ -22,9 +22,11 @@ function getLastCharIndex(font) {
 
 function createOS2Table(font) {
 
-  var buf = new ByteBuffer(86);
+  var buf = new ByteBuffer(96);
 
-  buf.writeUint16(1); //version
+  // fsSelection Bit 7 was defined in version 4. For new fonts, vendors are 
+  // encouraged to use a version 4 or later OS/2 table and to have bit 7 set.
+  buf.writeUint16(4); // version
   buf.writeInt16(font.avgWidth); // xAvgCharWidth
   buf.writeUint16(font.weightClass); // usWeightClass
   buf.writeUint16(font.widthClass); // usWidthClass
@@ -67,6 +69,11 @@ function createOS2Table(font) {
   buf.writeInt16(-Math.min(font.yMin, font.descent)); // usWinDescent
   buf.writeInt32(1); // ulCodePageRange1, Latin 1
   buf.writeInt32(0); // ulCodePageRange2
+  buf.writeInt16(710); // sxHeight  // TODO: 计算该值
+  buf.writeInt16(100); // sCapHeight // TODO: 计算该值
+  buf.writeUint16(0); // usDefaultChar
+  buf.writeUint16(32); // usBreakChar
+  buf.writeUint16(0); // usMaxContext
 
   return buf;
 }


### PR DESCRIPTION
fsSelection bit 7 was defined in version 4. For new fonts, vendors are encouraged to use a version 4 or later OS/2 table and to have bit 7 set.

Fixes: https://github.com/fontello/svg2ttf/issues/106