### PR TITLE
fix: OS/2 table version is bumped from 5 to 4

### DIFF
--- a/lib/ttf/tables/os2.js
+++ b/lib/ttf/tables/os2.js
@@ -20,6 +20,7 @@ function getLastCharIndex(font) {
   }))));
 }
 
+// OpenType spec: https://docs.microsoft.com/en-us/typography/opentype/spec/os2
 function createOS2Table(font) {
 
   // use at least 2 for ligatures and kerning
@@ -29,9 +30,10 @@ function createOS2Table(font) {
     return Math.max(a, b);
   }, 2);
 
-  var buf = new ByteBuffer(100);
+  var buf = new ByteBuffer(96);
 
-  buf.writeUint16(5); //version
+  // Version 5 is not supported in the Android 5 browser.
+  buf.writeUint16(4); // version
   buf.writeInt16(font.avgWidth); // xAvgCharWidth
   buf.writeUint16(font.weightClass); // usWeightClass
   buf.writeUint16(font.widthClass); // usWidthClass
@@ -81,10 +83,6 @@ function createOS2Table(font) {
   buf.writeUint16(0); // usDefaultChar, pointing to missing glyph (always id=0)
   buf.writeUint16(0); // usBreakChar, code=32 isn't guaranteed to be a space in icon fonts
   buf.writeUint16(maxContext); // usMaxContext, use at least 2 for ligatures and kerning
-  // if font isn't designed for multiple optical-sized variants,
-  // following fields should be 0x0000-0xFFFF
-  buf.writeUint16(0); // usLowerOpticalPointSize
-  buf.writeUint16(0xFFFF); // usUpperOpticalPointSize
 
   return buf;
 }

--- a/test/test.js
+++ b/test/test.js
@@ -61,15 +61,20 @@ describe('svg2ttf', function () {
 
 
   describe('os/2 table', function () {
+    let parsed = opentype.parse(svg2ttf(fixture).buffer.buffer);
+    let os2 = parsed.tables.os2;
+
     it('winAscent + winDescent should include line gap', function () {
       // https://www.high-logic.com/font-editor/fontcreator/tutorials/font-metrics-vertical-line-spacing
-      let parsed = opentype.parse(svg2ttf(fixture).buffer.buffer);
-      let os2 = parsed.tables.os2;
 
       // always should be >=, but for this specific test they should be equal
       assert.strictEqual(
         os2.usWinAscent + os2.usWinDescent,
         os2.sTypoAscender - os2.sTypoDescender + os2.sTypoLineGap);
+    });
+
+    it('os2.version = 4', function () {
+      assert.strictEqual(os2.version, 4);
     });
   });
 });


### PR DESCRIPTION
Version 5 is not supported in the Android 5 browser.

Fixes: 
- https://github.com/thx/iconfont-plus/issues/1999
- https://github.com/thx/iconfont-plus/issues/2001
- https://github.com/thx/iconfont-plus/issues/2003

## Before
Test case: https://at.alicdn.com/t/project/689429/4bdadfcb-9406-4c89-927b-421a1179862a.html

![image](https://user-images.githubusercontent.com/2784308/122352805-074b3700-cf82-11eb-97c3-a5190bab92b4.png)

## After
Test case: https://at.alicdn.com/t/project/689429/61d9cd01-ca82-439d-bbec-0aca73d3b180.html

![image](https://user-images.githubusercontent.com/2784308/122352838-0f0adb80-cf82-11eb-9c0a-e4a6aa3734fc.png)
