### PR TITLE
add an option to opt out of USE_TYPO_METRICS

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ API
   - `description` - description string (optional)
   - `ts` - Unix timestamp (in seconds) to override creation time (optional)
   - `url` - manufacturer url (optional)
+  - `useTypoMetrics` - [USE_TYPO_METRICS](https://docs.microsoft.com/en-us/typography/opentype/spec/os2#fsselection) boolean (optional, default=true)
   - `version` - font version string, can be `Version x.y` or `x.y`.
 - `buf` - internal [byte buffer](https://github.com/fontello/microbuffer)
    object, similar to DataView. It's `buffer` property is  `Uin8Array` or `Array`

--- a/index.js
+++ b/index.js
@@ -21,7 +21,9 @@ function svg2ttf(svgString, options) {
   var font = new sfnt.Font();
   var svgFont = svg.load(svgString);
 
-  options = options || {};
+  options = options || {
+    useTypoMetrics: true
+  };
 
   font.id = options.id || svgFont.id;
   font.familyName = options.familyname || svgFont.familyName || svgFont.id;
@@ -46,6 +48,12 @@ function svg2ttf(svgString, options) {
 
   if (typeof options.ts !== 'undefined') {
     font.createdDate = font.modifiedDate = new Date(parseInt(options.ts, 10) * 1000);
+  }
+
+  if (options.useTypoMetrics === false) {
+    // set "REGULAR" to fsSelection
+    // https://docs.microsoft.com/en-us/typography/opentype/spec/os2#fsselection
+    font.fsSelection = 0x40;
   }
 
   // Try to fill font metrics or guess defaults


### PR DESCRIPTION
Added `useTypoMetrics` options to set `REGULAR` to fsSelection.
https://docs.microsoft.com/en-us/typography/opentype/spec/os2#fsselection

**Use cases**
We use custom icon fonts generated thanks to `svg2ttf` in Flutter project.
Flutter renders extra ascent when `Use Typo Metrics` is enabled. `useTypoMetrics` options will solve this problem.

https://github.com/fontello/svg2ttf/issues/95#issuecomment-631370838